### PR TITLE
Fix assert in model.py

### DIFF
--- a/wals_ml_engine/trainer/model.py
+++ b/wals_ml_engine/trainer/model.py
@@ -343,7 +343,7 @@ def generate_recommendations(user_idx, user_rated, row_factor, col_factor, k):
   """
 
   # bounds checking for args
-  assert (row_factor.shape[0] - len(user_rated)) >= k
+  assert (col_factor.shape[0] - len(user_rated)) >= k
 
   # retrieve user factor
   user_f = row_factor[user_idx]


### PR DESCRIPTION
Found this bug when testing on a small dataset it fails when the number of items in the dataset is 3, the number of users is 10, the user rated 2, and I try to get 2 recommendations. 

The assert is supposed to check that the number of items in the dataset is greater than the number of requested recommendations plus the number of items a user already rated. The reason I changed `row_factor` with `col_factor` is `col_factor.shape[0]` is the number of items in the dataset.