### PR TITLE
FIX for ERROR: (gcloud.ml-engine.jobs.submit.training) --master-machine-type is required if scale-tier is set to `CUSTOM`.

### DIFF
--- a/wals_ml_engine/mltrain.sh
+++ b/wals_ml_engine/mltrain.sh
@@ -89,6 +89,7 @@ elif [[ ${TRAIN_JOB} == "train" ]]; then
     --job-dir ${BUCKET}/jobs/${JOB_NAME} \
     --module-name trainer.task \
     --package-path trainer \
+    --master-machine-type complex_model_m_gpu \
     --config trainer/config/config_train.json \
     -- \
     ${ARGS}
@@ -112,6 +113,7 @@ elif [[ $TRAIN_JOB == "tune" ]]; then
     --job-dir ${BUCKET}/jobs/${JOB_NAME} \
     --module-name trainer.task \
     --package-path trainer \
+    --master-machine-type standard_gpu \
     --config ${CONFIG_TUNE} \
     -- \
     --hypertune \


### PR DESCRIPTION
While following the [TensorFlow Recommendation System Tutorial](https://cloud.google.com/solutions/machine-learning/recommendation-system-tensorflow-train-cloud-ml-engine) I came across the following command not working as intended: `./mltrain.sh train ${BUCKET} data/ratings.csv --delimiter , --headers` with it producing the error: `ERROR: (gcloud.ml-engine.jobs.submit.training) --master-machine-type is required if scale-tier is set to `CUSTOM`.`. I found this result surprising because the masterType IS set in the config _train.json and config_tune.json files but we still get the error.